### PR TITLE
Correctly import relative module using AMD loader.

### DIFF
--- a/js/ladda.js
+++ b/js/ladda.js
@@ -13,7 +13,7 @@
 	}
 	// AMD module
 	else if( typeof define === 'function' && define.amd ) {
-		define( [ 'spin' ], factory );
+		define( [ './spin' ], factory );
 	}
 	// Browser global
 	else {


### PR DESCRIPTION
See [AMD specs](https://github.com/amdjs/amdjs-api/blob/master/AMD.md#module-id-format-) for more info.

Thanks for the awesome project. We really love it. This fix helps the Dojo build system correctly import the spin module.
