### PR TITLE
Replace div with span inside button

### DIFF
--- a/js/ladda.js
+++ b/js/ladda.js
@@ -141,7 +141,7 @@
 				}
 				else {
 					if( !progressElement ) {
-						progressElement = document.createElement( 'div' );
+						progressElement = document.createElement( 'span' );
 						progressElement.className = 'ladda-progress';
 						button.appendChild( progressElement );
 					}


### PR DESCRIPTION
According to the W3C validator, button elements must not contain divs.