### PR TITLE
Added a remove function

### DIFF
--- a/dist/ladda.js
+++ b/dist/ladda.js
@@ -47,6 +47,10 @@
                 }, 1e3);
                 return this;
             },
+            remove: function() {
+                spinnerWrapper.parentNode.removeChild(spinnerWrapper);
+                return this;
+            },
             toggle: function() {
                 if (this.isLoading()) {
                     this.stop();

--- a/dist/ladda.js
+++ b/dist/ladda.js
@@ -48,6 +48,9 @@
                 return this;
             },
             remove: function() {
+                if (this.isLoading()) {
+                    this.stop();
+                }
                 spinnerWrapper.parentNode.removeChild(spinnerWrapper);
                 return this;
             },


### PR DESCRIPTION
This is a proposed fix for issue #35 - duplicated spinner.  When calling the new remove function, the spinner is removed from the DOM, preventing a build up of duplicate spinners.